### PR TITLE
Bug 2.8.1

### DIFF
--- a/src/server/public/scripts/modules/FormCreate.js
+++ b/src/server/public/scripts/modules/FormCreate.js
@@ -176,7 +176,7 @@ export default class FormCreate {
         }.bind(this))
       }
 
-      var slugPaths = document.querySelectorAll('[data-slug-type=path]')
+      var slugPaths = this._form.querySelectorAll('[data-slug-type=path]')
       Array.prototype.forEach.call(slugPaths, function(slugPath) {
         var isStructureFolder = (slugPath.parentNode.getAttribute('data-shown') != null)
         if (slugPath.value != null && slugPath.value != '' && (isStructureFolder && !slugPath.parentNode.classList.contains('hidden'))) {

--- a/src/server/sass/modules/_editor.scss
+++ b/src/server/sass/modules/_editor.scss
@@ -14,6 +14,12 @@
   word-break: break-all;
 }
 
+#slug {
+  .autocomplete-result .glyphicon.glyphicon-remove {
+    display: inline-block;
+  }
+}
+
 .manager-wrapper {
   .form-create {
     padding: 0px 20px;


### PR DESCRIPTION
Fix bug on abe version 2.8.1
- css bug on status (not draft) precontribution glyph remove data result autocomplete was not visible (so it was impossible to remove autocomplete result)
- bug form precontribution level-1 document queryselector 2 value found -> expected only one