### PR TITLE
fix: on duplicate with same name

### DIFF
--- a/src/cli/cms/operations/duplicate.js
+++ b/src/cli/cms/operations/duplicate.js
@@ -38,7 +38,7 @@ const duplicate = function(oldPostUrl, template, newPath, name, req, isUpdate = 
 
     var pCreate = cmsOperations.create(template, newPath, name, req, json, (isUpdate) ? false : true)
     pCreate.then((resSave) => {
-      if (isUpdate && oldPostUrl !== newPostUrl) {
+      if (isUpdate && oldPostUrl !== path.join('/', newPostUrl)) {
         abeExtend.hooks.instance.trigger('beforeUpdate', json, oldPostUrl, template, newPath, name, req, isUpdate)
         cmsOperations.remove.remove(oldPostUrl)
       }


### PR DESCRIPTION
I choosed to add a "/" to the path because:
- the abe_meta.link start with a "/" inside json data file
- when we split the url after /abe/update/filename.html we remove "/abe/update/" so we need to add an extra "/" before filename