### PR TITLE
Issue 33

### DIFF
--- a/docs/types/abe-slug.md
+++ b/docs/types/abe-slug.md
@@ -17,6 +17,9 @@ Warning:
 
 ## Variables
 
+> this will be compiled with handlebars
+> You can use single variable, or statements
+
 variables can be added to slug url
 
 ```slug

--- a/src/cli/cms/editor/handlebars/printBlock.js
+++ b/src/cli/cms/editor/handlebars/printBlock.js
@@ -9,7 +9,7 @@ export default function printBlock (ctx, root) {
   }
 
   if(ctx[0].block != null && ctx[0].block !== '') {
-    res += `<div class="form-group">
+    res += `<div class="form-group" data-precontrib-templates="${ctx[0].precontribTemplate}">
               <label class="title">${ctx[0].block}</label>
               <div class='single-block well well-sm'>`
     Array.prototype.forEach.call(ctx, (item) => {
@@ -19,7 +19,7 @@ export default function printBlock (ctx, root) {
     res += '</div></div>'
   }else if(ctx[0].key.indexOf('[') > -1) {
     var ctxBlock = ctx[0].key.split('[')[0]
-    res += `<div class="form-group">
+    res += `<div class="form-group" data-precontrib-templates="${ctx[0].precontribTemplate}">
               <div class="list-group" data-block="${ctxBlock}" >
                 <label>
                   ${ctxBlock}

--- a/src/cli/cms/templates/template.js
+++ b/src/cli/cms/templates/template.js
@@ -319,6 +319,8 @@ export function setAbePrecontribDefaultValueIfDoesntExist(templateText) {
 export function getAbePrecontribFromTemplates(templatesList) {
   var fields = []
   var precontributionTemplate = ''
+
+  // loop over template file
   Array.prototype.forEach.call(templatesList, (file) => {
     var slugMatch = cmsData.regex.getTagAbeWithType(file.template, 'slug')
     var templateText = file.template
@@ -326,16 +328,9 @@ export function getAbePrecontribFromTemplates(templatesList) {
       templateText = cmsTemplates.template.setAbePrecontribDefaultValueIfDoesntExist(file.template)
     }
 
-    var matchesTabSlug = cmsData.regex.getTagAbeWithTab(templateText, 'slug')
-    Array.prototype.forEach.call(matchesTabSlug, (match) => {
-      fields.push(cmsData.attributes.getAll(match, {}))
-      var tag = match.replace(/\}\}$/, ' precontribTemplate="' + file.name + '"}}')
-      tag = tag.replace(/(key=[\'|\"])(.*?)([\'|\"])/, '$1/' + file.name + '/$2$3')
-      precontributionTemplate += `${tag}\n`
-    })
+    templateText = templateText.replace(/(?!.*?tab=['|"]slug)(\{\{abe.+.*)/g, ``)
+    precontributionTemplate += templateText.replace(/(\{\{abe.+)(\}\})/g, `$1 precontribTemplate="${file.name}"$2`)
   })
-
-  precontributionTemplate = cmsTemplates.template.addOrder(precontributionTemplate)
 
   return {
     fields: fields,

--- a/src/cli/cms/templates/template.js
+++ b/src/cli/cms/templates/template.js
@@ -333,7 +333,7 @@ export function getAbePrecontribFromTemplates(templatesList) {
   })
 
   return {
-    fields: fields,
+    // fields: fields,
     template: precontributionTemplate
   }
 }

--- a/src/server/public/abecms/scripts/devtool/Devtool.js
+++ b/src/server/public/abecms/scripts/devtool/Devtool.js
@@ -4,8 +4,7 @@ export class Devtool {
 
   constructor() {
     this.body = $('body')
-    this.form = $('.form-wrapper')
-    this.form = $('.form-wrapper')
+    this.form = $('.abeform-wrapper.form-wrapper')
     this.ruler = $('.iframe-wrapper')
     this.initDevtool()
     this.updateBrowserSize()

--- a/src/server/views/partials/engine.html
+++ b/src/server/views/partials/engine.html
@@ -1,5 +1,5 @@
 {{#if form}}
-<div class="no-gutter half-view form-wrapper status-{{@root.json.abe_meta.status}}" data-width="{{editorWidth}}" style="width:{{editorWidth}}">
+<div class="no-gutter half-view abeform-wrapper form-wrapper status-{{@root.json.abe_meta.status}}" data-width="{{editorWidth}}" style="width:{{editorWidth}}">
   <!-- *************** btn toolbar *************** -->
   <div class="toolbar">  
     <div class="btns">

--- a/src/server/views/partials/manager.html
+++ b/src/server/views/partials/manager.html
@@ -2,7 +2,7 @@
 <div class="no-gutter manager-wrapper {{#if form}}{{else}}visible{{/if}}">
 
   <!-- *************** left admin manager *************** -->
-  <div class="left">
+  <div class="left form-wrapper">
     {{#if isHome}}
     {{else}}
     <div class="clearfix">

--- a/test/cms/templates/template.js
+++ b/test/cms/templates/template.js
@@ -331,27 +331,10 @@ describe('cmsTemplates', function() {
   it('cmsTemplates.template.getAbePrecontribFromTemplates()', function() {
     // stub
     var sinonInstance = sinon.sandbox.create();
-    var stubGetTagAbeWithTab = sinonInstance.stub(cmsData.regex, 'getTagAbeWithTab');
-    stubGetTagAbeWithTab.returns(['{{abe type="slug" source="{{name}}"}}'])
-
-    var stubGetAll = sinonInstance.stub(cmsData.attributes, 'getAll');
-    stubGetAll.returns({name: 'test.html'})
-
-    var stubAddOrder = sinonInstance.stub(cmsTemplates.template, 'addOrder', function (text) {
-      return text
-    });
 
     // test
     var precontrib = cmsTemplates.template.getAbePrecontribFromTemplates([{name: 'slug', template: this.fixture.slug}])
-    chai.expect(precontrib.fields[0]).to.not.be.undefined;
-
-    // unstub
-    sinon.assert.calledOnce(cmsData.regex.getTagAbeWithTab)
-    cmsData.regex.getTagAbeWithTab.restore()
-    sinon.assert.calledOnce(cmsData.attributes.getAll)
-    cmsData.attributes.getAll.restore()
-    sinon.assert.calledOnce(cmsTemplates.template.addOrder)
-    cmsTemplates.template.addOrder.restore()
+    chai.expect(precontrib.template[0]).to.not.be.undefined;
   });
 
   /**


### PR DESCRIPTION
The pull request fix each statement with abe tags added the slug.

Use case:

```html
{{abe type="slug" source="/{{#each test}}{{title}}/{{/each}}/some-static-value"}}

<!DOCTYPE HTML>
<html>
	<body>
		<div>
		{{#each test}}
			<div>{{abe type='text' key='test.title' desc='Title' tab='slug'}}</div>
		{{/each}}
		</div>
	</body>
</html>
```

This also fix abe type data with each into slug

+ Now slug source attribute of abe type slug is compiled with handlebars (front side)