### PR TITLE
Issue 33

### DIFF
--- a/src/cli/cms/templates/template.js
+++ b/src/cli/cms/templates/template.js
@@ -351,7 +351,7 @@ export function setAbePrecontribDefaultValueIfDoesntExist(templateText) {
 
 export function getAbePrecontribFromTemplates(templatesList) {
   var fields = []
-  var precontributionTemplate = ''
+  var precontributionTemplate = []
 
   // loop over template file
   Array.prototype.forEach.call(templatesList, (file) => {
@@ -362,7 +362,8 @@ export function getAbePrecontribFromTemplates(templatesList) {
     }
 
     templateText = templateText.replace(/(?!.*?tab=['|"]slug)(\{\{abe.+.*)/g, ``)
-    precontributionTemplate += templateText.replace(/(\{\{abe.+)(\}\})/g, `$1 precontribTemplate="${file.name}"$2`)
+    templateText = templateText.replace(/(\{\{abe.+)(\}\})/g, `$1 precontribTemplate="${file.name}"$2`)
+    precontributionTemplate.push(templateText)
   })
 
   return {

--- a/src/server/public/abecms/scripts/modules/FormCreate.js
+++ b/src/server/public/abecms/scripts/modules/FormCreate.js
@@ -128,7 +128,7 @@ export default class FormCreate {
             var value = input.value
             var maxlength = input.getAttribute('data-maxlength')
             
-            var singleValues = values
+            var addTo = values
             if(id.indexOf('[') > -1) {
               var regexBlock = /(.*?)\[(\d*?)\]\.(.+)/
               var match = regexBlock.exec(id)

--- a/src/server/routes/get-main.js
+++ b/src/server/routes/get-main.js
@@ -160,13 +160,23 @@ var route = function(req, res, next) {
   })
 
   p.then((obj) => {
-    var precontrib = Manager.instance.getPrecontribution()
-    editor(precontrib.template, obj.json, '', true)
-      .then((resultPrecontrib) => {
-        EditorVariables.resultPrecontrib = resultPrecontrib
+    var precontribs = Manager.instance.getPrecontribution()
+    var promises = []
+    EditorVariables.resultPrecontrib = []
+    Array.prototype.forEach.call(precontribs.template, (precontrib) => {
+      var p = editor(precontrib, obj.json, '', true)
+        .then((resultPrecontrib) => {
+          EditorVariables.resultPrecontrib.push(resultPrecontrib)
+        }).catch(function(e) {
+          console.error(e)
+        })
+      promises.push(p)
+    })
+    Promise.all(promises)
+      .then(() => {
         renderAbeAdmin(EditorVariables, obj, filePath, isHome, template)
       }).catch(function(e) {
-        console.error(e)
+        console.error('source.js getDataList', e)
       })
   }).catch((e) => {
     console.log('error', e)

--- a/src/server/views/partials/create-form-tplname.html
+++ b/src/server/views/partials/create-form-tplname.html
@@ -1,5 +1,7 @@
-{{#each this.resultPrecontrib.form}}
-  {{#each this}}
-    {{{printBlock this @root}}}
-  {{/each}}
+{{#each this.resultPrecontrib}}
+  {{#each form}}
+	  {{#each this}}
+	    {{{printBlock this @root}}}
+	  {{/each}}
+	{{/each}}
 {{/each}}


### PR DESCRIPTION
Now `getAbePrecontribFromTemplates` func return an array of template.
`EditorVariables.resultPrecontrib` is also an array.

Since we loop over templates and not like before a single template, multiple abe tag with same keys aren't forgotten on the slug precontribution