### PR TITLE
fix: autocomplete source attributes doesn't escape single quote

### DIFF
--- a/src/server/public/abecms/scripts/modules/EditorJson.js
+++ b/src/server/public/abecms/scripts/modules/EditorJson.js
@@ -37,7 +37,7 @@ export default class Json {
         this.canSave = true
         return
       }
-      var jsonSave = this.data
+      var jsonSave = JSON.parse(JSON.stringify(this.data).replace(/&quote;/g, "\'"))
 
       if(typeof json.abe_source !== 'undefined' && json.abe_source !== null) {
         delete json.abe_source


### PR DESCRIPTION
after abe autocomplete input are saved inside json data, when editing a page and save it quote are not escape so they are save as &quote; and display like that inside saved html page