### PR TITLE
fix: first block each is not removed on click delete

### DIFF
--- a/src/server/public/abecms/scripts/modules/EditorSave.js
+++ b/src/server/public/abecms/scripts/modules/EditorSave.js
@@ -99,6 +99,7 @@ export default class EditorSave {
           }
           if(emptyObject === 0) {
             delete this._json.data[obj][index]
+            if(this._json.data[obj].length == 1) delete this._json.data[obj]
           }
         } else {
           if (input.getAttribute('data-autocomplete') === 'true' || input.getAttribute('data-multiple') === 'multiple') {


### PR DESCRIPTION
After saving if a block each that had only one element was removed, the block still appear after page reload