### PR TITLE
fix: sql request issue with order number

### DIFF
--- a/src/cli/core/utils/sort.js
+++ b/src/cli/core/utils/sort.js
@@ -56,6 +56,8 @@ export function predicatBy(prop, order){
   return function (a, b) {
     var i = 0
     while( i < len ) { a = a[prop[i]]; b = b[prop[i]]; i++ }
+    if (!isNaN(a)) a = parseFloat(a)
+    if (!isNaN(b)) b = parseFloat(b)
     if (a < b) {
       return -1*order
     } else if (a > b) {


### PR DESCRIPTION
Order by a key that is a number doesn't work with key saved with quote inside json data and nead to be parsed as a number before getting compared inside if statement