### PR TITLE
fix: abe tag w key containing hyphen donesn't work Fixes #26

### DIFF
--- a/src/cli/cms/editor/handlebars/compileAbe.js
+++ b/src/cli/cms/editor/handlebars/compileAbe.js
@@ -25,7 +25,7 @@ export default function compileAbe(){
     // hash.key = hash.key.replace(/\{\{@index\}\}/, '[{{@index}}]')
     hash.key = hash.key.replace(/\{\{@index\}\}/, `[${arguments[0].data.index}]`)
     try{
-      value = content ? eval(`content.${hash.dictionnary}[${arguments[0].data.index}].${key}`) : hash.key
+      value = content ? eval(`content["${hash.dictionnary}"][${arguments[0].data.index}]["${key}"]`) : hash.key
       // value = content ? content[hash['dictionnary']][arguments[0].data.index][key] : hash.key
     }
     catch(e){
@@ -50,7 +50,7 @@ export default function compileAbe(){
   hash = arguments[0].hash
   if(content) {
     try {
-      value = eval('content.' + hash.key)
+      value = eval(`content["${hash.key}"]`)
     }catch(e) {
       value = ''
     }

--- a/src/server/controllers/editor.js
+++ b/src/server/controllers/editor.js
@@ -9,7 +9,7 @@ import {
   abeExtend
 } from '../../cli'
 
-function add(obj, json, text, util) {
+export function add(obj, json, text, util) {
   var value = obj.value
 
   if(obj.key.indexOf('[') > -1) {
@@ -43,7 +43,7 @@ function add(obj, json, text, util) {
 
   util.add(obj)
 
-  return value
+  return obj.value
 }
 
 function getDataIdWithNoSlash(key) {

--- a/src/server/controllers/editor.js
+++ b/src/server/controllers/editor.js
@@ -19,18 +19,18 @@ function add(obj, json, text, util) {
     key = getDataIdWithNoSlash(key)
 
     try {
-      obj.value = eval('json[key][index].' + prop)
+      obj.value = eval(`json[key][index]["${prop}"]`)
     } catch(e) {
 
       try {
-        eval(`json[key][index].${prop} = ` + JSON.stringify(value))
+        eval(`json[key][index]["${prop}"] = ` + JSON.stringify(value))
       }catch(e) {
         // no value found inside json OKEY
       }
     }
   }else {
     try {
-      obj.value = eval(`json.${getDataIdWithNoSlash(obj.key)}`)
+      obj.value = eval(`json["${getDataIdWithNoSlash(obj.key)}"]`)
     } catch(e) {
       // no value found inside json OKEY
     }
@@ -79,7 +79,7 @@ function addToForm(match, text, json, util, arrayBlock, keyArray = null, i = 0) 
   }else if(util.dontHaveKey(obj.key) && cmsData.regex.isSingleAbe(v, text)) {
     realKey = obj.key//.replace(/\./g, '-')
     try {
-      obj.value = eval(`json.${getDataIdWithNoSlash(realKey)}`)
+      obj.value = eval(`json["${getDataIdWithNoSlash(realKey)}"]`)
     }catch(e) {
       obj.value = null
     }

--- a/test/controllers/editor.js
+++ b/test/controllers/editor.js
@@ -1,0 +1,37 @@
+var chai = require('chai');
+var sinonChai = require('sinon-chai')
+var expect = chai.expect
+chai.use(sinonChai)
+var sinon = require('sinon');
+var path = require('path');
+var fse = require('fs-extra');
+
+var config = require('../../src/cli').config
+config.set({root: path.join(process.cwd(), 'test', 'fixtures')})
+
+import data from '../fixtures/editor/add.json'
+import {add} from '../../src/server/controllers/editor'
+var Manager = require('../../src/cli').Manager;
+
+describe('editor', function() {
+  before( function(done) {
+        done()
+        
+  });
+
+  /**
+   * editor.add
+   * 
+   */
+  it('editor.add', function() {
+    var result = add(
+      data.obj,
+      data.json,
+      data.text,
+      {add:function () {}}
+    )
+
+    chai.expect(result).to.be.a('string');
+    chai.expect(result).to.be.equal('some text');
+  });
+});

--- a/test/fixtures/editor/add.json
+++ b/test/fixtures/editor/add.json
@@ -1,0 +1,5 @@
+{
+	"obj": {"desc":"test hyphen","display":null,"editable":true,"key":"test-hyphen","tab":"default","type":"text","value":null},
+	"json": {"test-hyphen":"some text"},
+	"text": "{{abe type='text' key='test-hyphen' desc='test hyphen' tab='default' order='0'}}"
+}


### PR DESCRIPTION
to allow hyphen inside key attributes eval() call use 'obj[key]' syntax instead of 'obj.key' syntax