### PR TITLE
fix: /site/ get remove & created when assets file are inside root folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "express-secure-handlebars": "^2.1.0",
     "express-session": "^1.13.0",
     "extend": "^3.0.0",
+    "fs-compare": "0.0.4",
     "fs-extra": "^2.0.0",
     "handlebars": "^4.0.3",
     "handlebars-helper-slugify": "^0.3.2",


### PR DESCRIPTION
if assets files inside index_files are not in sub folder, comparedir compare /index_files/ & /site/ which will be différentes (ex: html files published ...)
then everything inside /site/ will be erased and created again with content of /index_files/