### PR TITLE
Enhancement : Create a new route for serving plugin assets via Abe

### DIFF
--- a/src/cli/extend/plugins.js
+++ b/src/cli/extend/plugins.js
@@ -397,6 +397,28 @@ class Plugins {
 
     return p
   }
+
+  pluginExistsAtLocation(plugin, location) {
+    try {
+      var pluginDirectory = fse.lstatSync(path.join(config.root, location, plugin))
+      
+      return pluginDirectory.isDirectory() ? true : false
+    } catch (err) {
+
+      return false
+    }
+  }
+
+  getPluginLocation(plugin) {
+    var location = false
+    if (this.pluginExistsAtLocation(plugin, 'scripts')) {
+      location = 'scripts'
+    } else if (this.pluginExistsAtLocation(plugin, 'node_modules')) {
+      location = 'node_modules'
+    }
+
+    return location
+  }
 }
 
 export default Plugins

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -179,6 +179,8 @@ if(config.custom !== '') {
 
 var pluginsPartials = abeExtend.plugins.instance.getPartials()
 Array.prototype.forEach.call(pluginsPartials, (pluginPartials) => {
+  var pluginPath = pluginPartials.split('/')
+  app.use('/abe/plugins/' + pluginPath[pluginPath.length - 1], express.static(pluginPartials))
   app.use(express.static(pluginPartials))
 })
 

--- a/src/server/controllers/index.js
+++ b/src/server/controllers/index.js
@@ -28,7 +28,8 @@ import {
   users,
   getHome,
   postProfile,
-  rest
+  rest,
+  plugins
 } from '../routes'
 
 import {
@@ -155,6 +156,8 @@ Array.prototype.forEach.call(routes, (route) => {
     })
   }
 })
+
+router.get('/abe/plugins/*', plugins.getPluginsAssets)
 
 router.get('/abe*', getHome)
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -22,7 +22,7 @@ import postThemes from './post-themes'
 import * as users from './users'
 import * as operations from './operations'
 import * as rest from './rest'
-import * as plugins from './plugins'
+import * as plugins from './plugin'
 
 export {
 	getHome,

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -22,6 +22,7 @@ import postThemes from './post-themes'
 import * as users from './users'
 import * as operations from './operations'
 import * as rest from './rest'
+import * as plugins from './plugins'
 
 export {
 	getHome,
@@ -47,5 +48,6 @@ export {
 	postThemes,
 	users,
 	operations,
-	rest
+	rest,
+	plugins
 }

--- a/src/server/routes/plugin/get/plugins-assets.js
+++ b/src/server/routes/plugin/get/plugins-assets.js
@@ -1,0 +1,25 @@
+import fs from 'fs-extra'
+import path from 'path'
+
+import {
+  abeExtend,
+  config,
+} from '../../../../cli'
+
+var route = function route(req, res) {
+  if (typeof req.params !== 'undefined' && req.params[0].length > 0) {
+    var pluginUrl = req.params[0]
+    var pluginPath = pluginUrl.split('/')
+    var pluginLocation = abeExtend.plugins.instance.getPluginLocation(pluginPath[0])
+    if (pluginLocation) {
+    	var pluginFilePath = path.join(pluginPath.shift(), 'partials', ...pluginPath)
+    	res.sendFile(pluginFilePath, {root: path.join(config.root, pluginLocation)})
+    } else {
+    	res.status(404).send('Plugin Not found')
+    }
+  } else {
+      res.status(404).send('Not found')
+  }
+}
+
+export default route

--- a/src/server/routes/plugin/index.js
+++ b/src/server/routes/plugin/index.js
@@ -1,0 +1,5 @@
+import getPluginsAssets from './get/plugins-assets'
+
+export {
+	getPluginsAssets
+}

--- a/tests/unit/extend/plugin.js
+++ b/tests/unit/extend/plugin.js
@@ -165,4 +165,21 @@ describe('Plugin', function() {
     abeExtend.plugins.instance.remove.restore()
     done()
   });
+
+  it('abeExtend.plugins.instance.pluginExistsAtLocation(plugin, location)', function(done){
+    var locationScript = abeExtend.plugins.instance.pluginExistsAtLocation(this.fixture.testScript, './scripts')
+    var locationNodeModules = abeExtend.plugins.instance.pluginExistsAtLocation(this.fixture.testScript, './node_modules')
+    chai.assert.isBoolean(locationScript, 'pluginExistsAtLocation does not return a boolean')
+    chai.assert.isTrue(locationScript, 'pluginExistsAtLocation does not return TRUE when plugins exists at given location')
+    chai.assert.isNotTrue(locationNodeModules, 'pluginExistsAtLocation does not return FALSE when plugin does not exists at given location')
+
+    done()
+  })
+
+  it('abeExtend.plugins.instance.getPluginLocation(plugin)', function(done){
+    var location = abeExtend.plugins.instance.getPluginLocation(this.fixture.testScript)
+    chai.assert.equal(location, 'scripts', 'getPluginLocation does not return correct plugin location')
+
+    done()
+  })
 });


### PR DESCRIPTION
When I created the Abe colorpicker plugin, I encountered an issue with the plugin's assets.
Everything worked fine on my local, but when the site is behind an Apache server for delivering static assets, it cannot find the plugin's assets, like this :  ```<script src="/jscolor.min.js"></script>```
So I propose a new route for serving static plugins assets via Abe directly, like this : ```<script src="/abe/plugins/abe-colorpicker/jscolor.min.js"></script>```
This route contains the plugin name, following by the asset name.

When this route is matched, Abe will try to determine the plugin's location (either /scripts or /node_modules), and if it's found in the 'partials' folder of the plugin, it will be send via Abe.

This new route doesn't change the default behavior when there is no Apache server and doesn't break others plugins who doesn't use it.