### PR TITLE
fix: save on page /abe/list-url give everyone all the right to any route

### DIFF
--- a/src/cli/users/utils.js
+++ b/src/cli/users/utils.js
@@ -211,7 +211,7 @@ export function isUserAllowedOnRoute(workflow, currentRoute) {
       return true
     }
 
-    if (currentRoute.indexOf('abe/') === -1) {
+    if (currentRoute.indexOf('/abe') === -1) {
       isAllowed = true
     }
 


### PR DESCRIPTION
on route /abe/list-url, the last route is /abe* and the regex was matching "abe/" so after saving everyone were getting every access to any route