### PR TITLE
Fix: bug ask for new prefill on frontend

### DIFF
--- a/src/server/routes/post-sql-request.js
+++ b/src/server/routes/post-sql-request.js
@@ -7,19 +7,17 @@ var route = function(req, res, next) {
   if (typeof res._header !== 'undefined' && res._header !== null) return
 
   var sourceString = req.body.sourceString
-  var prefillQuantity = req.body.prefillQuantity
-  var folder = url.parse(req.header('referer')).path
-  folder = folder.replace('/abe/editor', '')
-  folder = path.dirname(folder)
+  var prefillQuantity = req.body.prefillQuantity != null && req.body.prefillQuantity != 'null' ? `prefill-quantity="${req.body.prefillQuantity}"` : ''
   var key = req.body.key
-  var jsonPage = req.body.json ? JSON.parse(JSON.stringify(req.body.json)) : {}
+  var jsonPage = req.body.json ? JSON.parse(JSON.stringify(req.body.json)) : {abe_meta: {}}
+  jsonPage.abe_meta.link = url.parse(req.header('referer')).path.replace('/abe/editor', '')
 
   jsonPage[key] = null
 
-  var request = `{{abe type="data" key="${key}" source="${sourceString}" prefill="true" prefill-quantity='${prefillQuantity}' editable="true"}}`
+  var request = `{{abe type="data" key="${key}" source="${sourceString}" prefill="true" ${prefillQuantity} editable="true"}}`
   var obj = cmsData.attributes.getAll(request, jsonPage)
 
-  cmsData.source.requestList(obj, folder, request, jsonPage).then(() => {
+  cmsData.source.requestList(obj, request, jsonPage).then(() => {
     res.set('Content-Type', 'application/json')
     res.send(JSON.stringify(jsonPage[key]))
   })


### PR DESCRIPTION
- Removed extra variable `folder` on `cmsData.source.requestList` the folder path need to be set on `abe_meta.link` jsonPage
- if the `prefill-quantity` attribute is not set (equal to `'null'`) the attribute doesn't need to be on the abe-tag