### PR TITLE
bug: iframe reload on safari

### DIFF
--- a/src/server/public/abecms/scripts/modules/EditorReload.js
+++ b/src/server/public/abecms/scripts/modules/EditorReload.js
@@ -71,11 +71,14 @@ export default class Reload {
       document.querySelector('#page-template').getAttribute('data-iframe-src')
     )
 
+    var hasNotWritten = true
+
     var initIframe = function() {
       var doc = iframe.contentWindow.document
       str = str.replace(/<\/head>/, '<base href="/" /></head>')
       doc.open('text/html', 'replace')
       doc.write(str)
+      hasNotWritten = false
       doc.close()
 
       setTimeout(function() {
@@ -92,6 +95,7 @@ export default class Reload {
     }
 
     iframe.onload = function() {
+      if(!hasNotWritten) return
       initIframe()
       setTimeout(function() {
         parent.classList.remove('reloading')


### PR DESCRIPTION
Fixes #229
after opening and writing inside iframe document, *close* method get invoked which lead to onload event, which call initIframe() and so on ...
i don't really get why only safari seems get buggy while all browsers should be broken, @nicolaslabbe told me it happens on chrome using abe latest version