### PR TITLE
2.16.x

### DIFF
--- a/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
+++ b/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
@@ -373,7 +373,7 @@ export default class EditorAutocomplete {
             theMatch = match[1].split('.')[0]
             key = match[1].split('.')[1]
           }
-          var selector = target.form.querySelector('[data-id="' + theMatch + '"]')
+          var selector = target.form.querySelector('[data-precontrib-templates="'+document.querySelector('#selectTemplate ').value+'"] [data-id="' + theMatch + '"]')
           if(selector != null) {
             var value = selector.value
             if(key != null) value = JSON.parse(selector.value)[key]

--- a/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
+++ b/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
@@ -365,7 +365,7 @@ export default class EditorAutocomplete {
       var dataVal = target.getAttribute('data-value').replace(/&quote;/g, '\'')
 
       if(dataVal.indexOf('{{') > -1){
-        var match
+        var match 
         while (match = /\{\{(.*?)\}\}/.exec(dataVal)) {
           var key = null
           var theMatch = match[1]

--- a/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
+++ b/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
@@ -373,7 +373,7 @@ export default class EditorAutocomplete {
             theMatch = match[1].split('.')[0]
             key = match[1].split('.')[1]
           }
-          var selector = target.form.querySelector('[data-precontrib-templates="'+document.querySelector('#selectTemplate ').value+'"] [data-id="' + theMatch + '"]')
+          var selector = target.form.querySelector('[data-precontrib-templates][style="display: block;"] [data-id="' + theMatch + '"]')
           if(selector != null) {
             var value = selector.value
             if(key != null) value = JSON.parse(selector.value)[key]

--- a/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
+++ b/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
@@ -377,8 +377,6 @@ export default class EditorAutocomplete {
           if(selector != null) {
             var value = selector.value
             if(key != null) value = JSON.parse(selector.value)[key]
-            console.log("dataVal", dataVal)
-            console.log("value", value)
             dataVal = dataVal.replace('{{' + match[1] + '}}', value)
           }
         }

--- a/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
+++ b/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
@@ -367,9 +367,19 @@ export default class EditorAutocomplete {
       if(dataVal.indexOf('{{') > -1){
         var match
         while (match = /\{\{(.*?)\}\}/.exec(dataVal)) {
-          var selector = target.form.querySelector('[data-id="' + match[1] + '"]')
+          var key = null
+          var theMatch = match[1]
+          if(match[1].indexOf('.') > -1) {
+            theMatch = match[1].split('.')[0]
+            key = match[1].split('.')[1]
+          }
+          var selector = target.form.querySelector('[data-id="' + theMatch + '"]')
           if(selector != null) {
-            dataVal = dataVal.replace('{{' + match[1] + '}}', selector.value)
+            var value = selector.value
+            if(key != null) value = JSON.parse(selector.value)[key]
+            console.log("dataVal", dataVal)
+            console.log("value", value)
+            dataVal = dataVal.replace('{{' + match[1] + '}}', value)
           }
         }
       }

--- a/src/server/public/abecms/scripts/modules/EditorSave.js
+++ b/src/server/public/abecms/scripts/modules/EditorSave.js
@@ -107,6 +107,7 @@ export default class EditorSave {
           }
           if(emptyObject === 0) {
             delete this._json.data[obj][index]
+            if(typeof this._json.data[obj][0] === 'undefined' || this._json.data[obj][0] === null) delete this._json.data[obj];
           }
         } else {
           if (input.getAttribute('data-autocomplete') === 'true' || input.getAttribute('data-multiple') === 'multiple') {


### PR DESCRIPTION
Exemple to reproduce this bug :
inside html template :
`{{abe type='data' key='someajax' source="https://www.url_that_return_json?locale={{langkey.the-value}}&name=" autocomplete="true" max-length="1" display="{{title}}" precontrib='true' desc='Country' visible="false" tab='slug' order='10'}}`

inside reference json file
```
[
  {
    "the-value": "fr",
    "key": "fr"
  },
  {
    "the-value": "pt-br",
    "key": "pt-br"
  },
  {
    "the-value": "de",
    "key": "de"
  },
  {
    "the-value": "gb",
    "key": "gb"
  },
  {
    "the-value": "es",
    "key": "es"
  },
  {
    "the-value": "it",
    "key": "it"
  },
  {
    "the-value": "nl",
    "key": "nl"
  },
  {
    "the-value": "pl",
    "key": "pl"
  },
  {
    "the-value": "pt",
    "key": "pt"
  },
  {
    "the-value": "ru",
    "key": "ru"
  }
]
```
as `{{langkey.the-value}}` use a child property of langkey it doesn't work
