### PR TITLE
Feature abe type data

### DIFF
--- a/src/cli/cms/data/attributes.js
+++ b/src/cli/cms/data/attributes.js
@@ -62,10 +62,10 @@ export function sanitizeSourceAttribute(obj, jsonPage){
         
         try {
           val = eval('jsonPage.' + val)
+          obj.sourceString = obj.sourceString.replace(match, val)
         }catch(e) {
           val = ''
         }
-        obj.sourceString = obj.sourceString.replace(match, val)
       })
     }
   }

--- a/src/cli/cms/data/source.js
+++ b/src/cli/cms/data/source.js
@@ -154,12 +154,12 @@ export function nextDataList(tplPath, jsonPage, match) {
     }
 
     var obj = cmsData.attributes.getAll(match, jsonPage)
-    obj = cmsData.attributes.sanitizeSourceAttribute(obj, jsonPage)
     
     var type = cmsData.sql.getSourceType(obj.sourceString)
     
     switch (type) {
     case 'request':
+      obj = cmsData.attributes.sanitizeSourceAttribute(obj, jsonPage)
       requestList(obj, tplPath, match, jsonPage)
           .then((jsonPage) => {
             resolve(jsonPage)
@@ -168,6 +168,7 @@ export function nextDataList(tplPath, jsonPage, match) {
           })
       break
     case 'value':
+      obj = cmsData.attributes.sanitizeSourceAttribute(obj, jsonPage)
       valueList(obj, match, jsonPage)
           .then(() => {
             resolve()
@@ -184,6 +185,7 @@ export function nextDataList(tplPath, jsonPage, match) {
           })
       break
     case 'file':
+      obj = cmsData.attributes.sanitizeSourceAttribute(obj, jsonPage)
       fileList(obj, tplPath, match, jsonPage)
           .then(() => {
             resolve()

--- a/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
+++ b/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
@@ -112,7 +112,7 @@ export default class EditorAutocomplete {
       }
     }
 
-    var results = [].slice.call(this._currentInput.parentNode.querySelectorAll('.autocomplete-result-wrapper .autocomplete-result'))
+    var results = this._currentInput && [].slice.call(this._currentInput.parentNode.querySelectorAll('.autocomplete-result-wrapper .autocomplete-result')) || []
     var json = this._json.data
     
     var toSave = []
@@ -146,7 +146,8 @@ export default class EditorAutocomplete {
       }
 
     }else if(typeof id !== 'undefined' && id !== null) {
-      if (this._currentInput.getAttribute('visible') === true) {
+      if (typeof this._currentInput !== 'undefined' && this._currentInput !== null
+        && this._currentInput.getAttribute('visible') === true) {
         var nodes = EditorUtils.getNode(attr)
         Array.prototype.forEach.call(nodes, (node) => {
           EditorUtils.formToHtml(node, this._currentInput)
@@ -362,7 +363,9 @@ export default class EditorAutocomplete {
       }else {
         this._previousValue = val
       }
-      var dataVal = target.getAttribute('data-value').replace(/&quote;/g, '\'')
+      var dataVal = target.getAttribute('data-value').replace(/&quote;/g, "'")
+      var template = Handlebars.compile(dataVal, {noEscape: true}) 
+      dataVal = template(this._json.data)
 
       if(dataVal.indexOf('{{') > -1){
         var match

--- a/src/server/public/abecms/scripts/modules/EditorInputs.js
+++ b/src/server/public/abecms/scripts/modules/EditorInputs.js
@@ -39,7 +39,7 @@ export default class EditorInputs {
 
   rebind() {
     this._reloads = [].slice.call(document.querySelectorAll('[reload=true]:not([data-multiple="multiple"])'))
-    this._inputs = [].slice.call(document.querySelectorAll('input.form-abe'))
+    this._inputs = [].slice.call(document.querySelectorAll('.form-abe'))
     this._inputs = this._inputs.concat([].slice.call(document.querySelectorAll('textarea.form-abe')))
 
     Array.prototype.forEach.call(this._reloads, (reload) => {

--- a/src/server/public/abecms/scripts/modules/EditorSave.js
+++ b/src/server/public/abecms/scripts/modules/EditorSave.js
@@ -41,7 +41,7 @@ export default class EditorSave {
    * @return {Object} json
    */
   serializeForm() {
-    var abeForm = document.querySelector('.abeform-wrapper')
+    var abeForm = document.querySelector('.abeform-wrapper') || document.querySelector('.form-create')
     if (abeForm == null) return
     var e = document.getElementById('selectTemplate')
     var selectedTemplate = e.options[e.selectedIndex].value
@@ -87,7 +87,11 @@ export default class EditorSave {
               }
             })
           } else if (input.value.indexOf('{') > -1 || input.value.indexOf('[') > -1) {
-            value = JSON.parse(input.value)
+            try { 
+              value = JSON.parse(input.value) 
+            }catch(e) { 
+              value = null 
+            }
           } else {
             value = input.value
           }
@@ -123,7 +127,11 @@ export default class EditorSave {
               }
             })
           } else if (input.value.indexOf('{') > -1) {
-            value = JSON.parse(input.value)
+            try { 
+              value = JSON.parse(input.value) 
+            }catch(e) { 
+              value = null 
+            }
           } else {
             value = input.value
           }


### PR DESCRIPTION
When you use abe type data on the precontrib,
You should be able to use previously contribued variables on abe type data url autocomplete

Example: 

```html
{{abe type='slug' source='{{page_name}}.{{lang.value}}'}}

{{abe type='data' key='lang' desc='Language' source='[{"value": "fr"}, {"value": "es"}, {"value": "de"}]' display='value' max-length="1" visible="false" tab='slug' order='4'}}

{{abe type='data' key='durville' source='https://www.durville.io/api/Geo/findByCity?locale={{lang.value}}&name=' max-length="1" autocomplete="true" display="{{nomofficielfils}} ({{countryname}})" desc='durville' visible='false' tab='slug' order='2'}}
```