### PR TITLE
abe type translate

### DIFF
--- a/src/cli/cms/templates/handlebars/translate.js
+++ b/src/cli/cms/templates/handlebars/translate.js
@@ -1,14 +1,30 @@
 import {coreUtils} from '../../../'
-
-export default function translate(lang, str) {
-  var trad = coreUtils.locales.instance.i18n
-  if (
-    typeof trad[lang] !== 'undefined' &&
-    trad[lang] !== null &&
-    typeof trad[lang][str] !== 'undefined' &&
-    trad[lang][str] !== null
-  ) {
-    return trad[lang][str]
+import Handlebars from 'handlebars'
+ 
+function getVariable(variable, json, options) {
+  if (variable.indexOf('{{') > -1) {
+    var template = Handlebars.compile(variable)
+    var res = template(json)
+ 
+    if (res === "") {
+      template = Handlebars.compile(variable)
+      res = template(options.data.root)
+    }
+    return res
+  }else {
+    return variable
   }
-  return str
+}
+ 
+export default function translate(lang, str, json, options) {
+  var resLang = getVariable(lang, json, options)
+  var resStr = getVariable(str, json, options)
+ 
+  var trad = coreUtils.locales.instance.i18n
+  if(typeof trad[resLang] !== 'undefined' && trad[resLang] !== null
+    && typeof trad[resLang][resStr] !== 'undefined' && trad[resLang][resStr] !== null) {
+    return trad[resLang][resStr]
+  }
+ 
+  return resStr
 }

--- a/src/cli/cms/templates/template.js
+++ b/src/cli/cms/templates/template.js
@@ -218,26 +218,7 @@ export function translate(text) {
           var locale = cmsData.regex.getAttr(currentMatch, 'locale')
           var source = cmsData.regex.getAttr(currentMatch, 'source')
 
-          if (locale.indexOf('{{') === -1) {
-            locale = `'${locale}'`
-          } else {
-            locale = locale.replace(/\{\{(.*?)\}\}/, '$1')
-          }
-
-          if (source.indexOf('{{') === -1) {
-            source = `'${source.replace(/'/g, "\\'")}'`
-          } else {
-            source = source.replace(/\{\{(.*?)\}\}/, '$1')
-          }
-
-          // var replace = `{{{i18nAbe ${locale} ${source}}}}`
-          var replace = currentMatch.replace('{{abe', '{{i18nAbe')
-          replace = replace.replace(/locale=['|"].*?['|"]/, locale)
-          replace = replace.replace(/source=['|"].*?['|"]/, source)
-          replace = replace.replace(
-            /{{i18nAbe.*?}}/,
-            `{{{i18nAbe ${locale} ${source}}}}`
-          )
+          var replace = `{{{i18nAbe "${locale}" "${source}" this}}}`
 
           text = text.replace(
             cmsData.regex.escapeTextToRegex(currentMatch, 'g'),


### PR DESCRIPTION
should accepte {{variable}} for source attribute

Exemple:

```
{{abe type="translate" source="{{some.variable}}" locale="{{lang.value}}"}}
```