### PR TITLE
bug: emty bloc is created after save

### DIFF
--- a/src/server/public/abecms/scripts/modules/EditorSave.js
+++ b/src/server/public/abecms/scripts/modules/EditorSave.js
@@ -111,6 +111,7 @@ export default class EditorSave {
           }
           if(emptyObject === 0) {
             delete this._json.data[obj][index]
+            if(typeof this._json.data[obj][0] === 'undefined' || this._json.data[obj][0] === null) delete this._json.data[obj];
           }
         } else {
           if (input.getAttribute('data-autocomplete') === 'true' || input.getAttribute('data-multiple') === 'multiple') {


### PR DESCRIPTION
on2.16 only If not each bloc is added by hittting +, an empty bloc will be created