### PR TITLE
fix: regex not enough strong

### DIFF
--- a/src/cli/cms/data/sql.js
+++ b/src/cli/cms/data/sql.js
@@ -321,7 +321,7 @@ export function executeQuery(pathexecuteQuery, match, jsonPage) {
  * @return {String} url | request | value | file | other
  */
 export function getSourceType(str) {
-  if(/^(http:\/\/|https:\/\/|:\/\/)|(\?(.*)=)/.test(str)) {
+  if(/^(http:\/\/|https:\/\/|:\/\/|\/(.*)\?(.*)[^ ]=)/.test(str)) {
     return 'url'
   }
 

--- a/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
+++ b/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
@@ -377,7 +377,7 @@ export default class EditorAutocomplete {
         }
       }
 
-      if(/^(http:\/\/|https:\/\/|:\/\/)|(\?(.*)=)/.test(dataVal)) {
+      if(/^(http:\/\/|https:\/\/|:\/\/|\/(.*)\?(.*)[^ ]=)/.test(dataVal)) {
         this._ajax(
           {
             url: `${dataVal}${val}`,


### PR DESCRIPTION
improve this commit : 
https://github.com/abecms/abecms/commit/e86c0c40eef7a71ae512e8a8aba0f5957f87d248

The regex could catch wrong string and interpret them as url while it was not.

for exemple try the previous regexp `/^(http:\/\/|https:\/\/|:\/\/)|(\?(.*)=)/`

with this (this is the result from an abe sql tag that could select article from abe data) : 

```
"[{"title": "Where is Abe ?","description": "<span style=\"font-wright:bold\">Abe is in the kitchen</span>"}]"
```
1) On the backend the regex will test an sql query which will work and create automplete input on the frontend editor

2) on the frontend editor when the autocompletion will start, the regexp will catch it as an url because of the ? in the title property, and the = on the description property (for example from abe rich tag). this will leads to this javascript error in the browser

```
Uncaught SyntaxError: Unexpected token < in JSON at position 0
    at JSON.parse (<anonymous>)
    at template-engine-compiled.js:formatted:16811
    at template-engine-compiled.js:formatted:15673
    at XMLHttpRequest.req.onreadystatechange (template-engine-compiled.js:formatted:15683)
(anonymous) @ template-engine-compiled.js:formatted:16811
(anonymous) @ template-engine-compiled.js:formatted:15673
req.onreadystatechange @ template-engine-compiled.js:formatted:15683
XMLHttpRequest.send (async)
XMLHttpRequest.send @ user-login-compiled.js:1243
exports.ajax @ template-engine-compiled.js:formatted:15703
_startAutocomplete @ template-engine-compiled.js:formatted:16805
_keyUp @ template-engine-compiled.js:formatted:16825
```