### PR TITLE
fix: max-lenght properties is broken

### DIFF
--- a/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
+++ b/src/server/public/abecms/scripts/modules/EditorAutocomplete.js
@@ -100,18 +100,6 @@ export default class EditorAutocomplete {
     var nodeComments = IframeCommentNode('#page-template', id.replace(/\./g, '-'))
     var maxLength = this._currentInput.getAttribute('data-maxlength')
 
-    if(typeof maxLength !== 'undefined' && maxLength !== null && maxLength !== '') {
-      maxLength = parseInt(maxLength)
-      var countLength = [].slice.call(this._currentInput.parentNode.querySelectorAll('.autocomplete-result-wrapper .autocomplete-result')).length
-      if(countLength === maxLength) {
-        this._currentInput.value = ''
-        this._divWrapper.parentNode.removeChild(this._divWrapper)
-        this._currentInput.setAttribute('disabled', 'disabled')
-      }else {
-        this._currentInput.removeAttribute('disabled')
-      }
-    }
-
     var results = this._currentInput && [].slice.call(this._currentInput.parentNode.querySelectorAll('.autocomplete-result-wrapper .autocomplete-result')) || []
     var json = this._json.data
     
@@ -152,6 +140,18 @@ export default class EditorAutocomplete {
         Array.prototype.forEach.call(nodes, (node) => {
           EditorUtils.formToHtml(node, this._currentInput)
         })
+      }
+    }
+
+    if(typeof maxLength !== 'undefined' && maxLength !== null && maxLength !== '') {
+      maxLength = parseInt(maxLength)
+      var countLength = [].slice.call(this._currentInput.parentNode.querySelectorAll('.autocomplete-result-wrapper .autocomplete-result')).length
+      if(countLength === maxLength) {
+        this._currentInput.value = ''
+        this._divWrapper.parentNode.removeChild(this._divWrapper)
+        this._currentInput.setAttribute('disabled', 'disabled')
+      }else {
+        this._currentInput.removeAttribute('disabled')
       }
     }
 


### PR DESCRIPTION
While using max-length attribute inside abe tag type source i did notice that when reaching the max-length number after iframe reload the array of data for this tag was empty and i needed to click save so the page would reload and display my array items.

**How to reproduce this bug :**
`projet structure :`
```bash
├── data
├── reference
│   ├── ref.json
├── site
├── templates
│   ├── index.html
├── package.json
```
`ref.json :`
```javascript
[
  { "key": "key_1" },
  { "key": "key_2" },
  { "key": "key_3" },
  { "key": "key_4" }
]
```
```html
<!DOCTYPE html>
<html lang="fr" xml:lang="fr">
  <head></head>
  <body>
  {{abe type='data' key='refs' desc='some ref' source='reference/ref.json' display='key' visible='true' editable='true' autocomplete='true' max-length='4'}}
  {{#each refs}}
    {{key}}
    <br>
  {{/each}}
  </body>
</html>
```
after selecting the fourth item, nothing will be displayed.

**Fix :**
So what i did to fix this issue is to move the part of the code, that disable and remove the value from the input, from the begining to the end of `_saveData()`  from `EditorAutocomplete.js`